### PR TITLE
Fixed mispelling of pwnedornot() which caused it to be uninstallable

### DIFF
--- a/lazymux.py
+++ b/lazymux.py
@@ -119,7 +119,7 @@ def main():
 			elif infox.strip() == "27": asu()
 			elif infox.strip() == "28": fim()
 			elif infox.strip() == "29": maxsubdofinder()
-			elif infox.strip() == "30": pwnedOrNot()
+			elif infox.strip() == "30": pwnedornot()
 			elif infox.strip() == "31": maclook()
 			elif infox.strip() == "32": billcypher()
 			elif infox.strip() == "33": dnsrecon()


### PR DESCRIPTION
I think this was just a typo, but it made the tool uninstallable.
Tested after fixing it and it seems to work now!